### PR TITLE
Add --exclude-regex option to exclude files from deletion

### DIFF
--- a/ap_empty_directory/cli.py
+++ b/ap_empty_directory/cli.py
@@ -38,6 +38,13 @@ def main():
         action="store_true",
         help="enable debug output",
     )
+    parser.add_argument(
+        "--exclude-regex",
+        "-e",
+        type=str,
+        default=None,
+        help="regex pattern to exclude files from deletion (matched against filename)",
+    )
 
     args = parser.parse_args()
 
@@ -47,6 +54,7 @@ def main():
             recursive=args.recursive,
             dryrun=args.dryrun,
             debug=args.debug,
+            exclude_regex=args.exclude_regex,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)


### PR DESCRIPTION
Adds a new CLI option (-e/--exclude-regex) that accepts a regex pattern to exclude matching files from deletion. This enables users to keep specific files like .keep in directories to preserve sync configurations.

https://claude.ai/code/session_01US94gTJncNrFRvmT2WGF9X