### PR TITLE
Enforce typecheck in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ format: install-dev
 	$(PYTHON) -m black ap_empty_directory tests
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_empty_directory || true
+	$(PYTHON) -m mypy ap_empty_directory
 
 coverage: install-dev
 	$(PYTHON) -m pytest --cov=ap_empty_directory --cov-report=term


### PR DESCRIPTION
- Remove || true from typecheck target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)