### PR TITLE
Add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+## Documentation
+
+This tool is part of the astrophotography pipeline. For comprehensive documentation, see:
+
+- [Pipeline Overview](https://github.com/jewzaam/ap-base/blob/main/docs/index.md) - Introduction to the pipeline architecture
+- [Workflow Guide](https://github.com/jewzaam/ap-base/blob/main/docs/workflow.md) - Step-by-step processing workflows
+- [Tool API Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-empty-directory.md) - Detailed documentation for this tool
+
 Remove files from a directory and clean up empty subdirectories.
 
 ## Overview


### PR DESCRIPTION
## Summary
Added a new Documentation section to the README that links to comprehensive guides for the astrophotography pipeline and this tool's API reference.

## Changes
- Added a "Documentation" section with links to:
  - Pipeline Overview - Introduction to the pipeline architecture
  - Workflow Guide - Step-by-step processing workflows
  - Tool API Reference - Detailed documentation specific to this tool

## Details
This improves discoverability of documentation for users and contributors by providing clear entry points to the pipeline documentation hosted in the ap-base repository. The links are positioned prominently in the README, right after the badges and before the tool description.

https://claude.ai/code/session_01PbfqiK4M2eMiGyKcZ5z73d