### PR TITLE
Convert print statements to logging infrastructure

### DIFF
--- a/ap_empty_directory/cli.py
+++ b/ap_empty_directory/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 
+from ap_common.logging_config import setup_logging
 from ap_empty_directory.empty import empty_directory
 
 # Exit codes
@@ -54,13 +55,14 @@ def main():
 
     args = parser.parse_args()
 
+    # Setup logging
+    setup_logging(name="ap_empty_directory", debug=args.debug, quiet=args.quiet)
+
     try:
         empty_directory(
             directory=args.directory,
             recursive=args.recursive,
             dryrun=args.dryrun,
-            debug=args.debug,
-            quiet=args.quiet,
             exclude_regex=args.exclude_regex,
         )
     except ValueError as e:


### PR DESCRIPTION
Replace all print statements with proper logging calls using module-level logger. Remove quiet and debug parameters from functions (both handled by logging level set via setup_logging).

Changes:
- Add module-level logger using logging.getLogger(__name__)
- Import setup_logging and call it in CLI with quiet=args.quiet
- Convert print() to logger.debug/info/warning as appropriate
- Remove quiet and debug parameters from all function signatures
- Update CLI to only pass dryrun, recursive, exclude_regex
- Update tests to use caplog fixture and specify logger name
- Update test to reflect debug-takes-precedence-over-quiet behavior

All 39 tests pass (1 skipped).

Addresses ap-base plan: Quiet Mode Support (Phase 3)

Assisted-by: Claude Code (Claude Sonnet 4.5)