### PR TITLE
Fix docstring formatting and flake8 configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-verbose: install-dev
 	$(PYTHON) -m pytest -v
 
 lint: install-dev
-	$(PYTHON) -m flake8 --max-line-length=88 --extend-ignore=E203,W503,E501,F401 ap_empty_directory tests
+	$(PYTHON) -m flake8 --max-line-length=88 --extend-ignore=E203,W503 ap_empty_directory tests
 
 format: install-dev
 	$(PYTHON) -m black ap_empty_directory tests

--- a/ap_empty_directory/empty.py
+++ b/ap_empty_directory/empty.py
@@ -76,7 +76,8 @@ def delete_files_in_directory(
         directory: Path to the directory to empty
         recursive: If True, delete files in subdirectories as well
         dryrun: If True, log what would be deleted without actually deleting
-        exclude_regex: Regex pattern to exclude files from deletion (matched against filename)
+        exclude_regex: Regex pattern to exclude files from deletion
+            (matched against filename)
 
     Returns:
         List of files that failed to delete (empty if all succeeded)
@@ -132,7 +133,8 @@ def empty_directory(
         directory: Path to the directory to empty
         recursive: If True, delete files in subdirectories as well
         dryrun: If True, log what would be deleted without actually deleting
-        exclude_regex: Regex pattern to exclude files from deletion (matched against filename)
+        exclude_regex: Regex pattern to exclude files from deletion
+            (matched against filename)
 
     Returns:
         List of files that failed to delete (empty if all succeeded)


### PR DESCRIPTION
## Summary
This PR improves code quality by fixing docstring formatting and updating the flake8 linting configuration.

## Key Changes
- **Docstring formatting**: Split long `exclude_regex` parameter descriptions across multiple lines in both `delete_files_in_directory()` and `empty_directory()` functions for better readability and compliance with line length standards
- **Flake8 configuration**: Removed `E501` (line too long) and `F401` (unused imports) from the ignore list in the Makefile, enabling stricter linting checks for these rules

## Implementation Details
The docstring changes wrap the clarification text "(matched against filename)" onto a continuation line with proper indentation, making the documentation more readable while maintaining consistency with PEP 257 conventions.

The flake8 configuration update removes overly permissive ignore rules, which will help catch actual issues with line length violations and unused imports during linting.

https://claude.ai/code/session_01P8YGW4CjyZAwUAESyP4Nff